### PR TITLE
Fix QT 6.4.x deprecation

### DIFF
--- a/src/o2simplecrypt.cpp
+++ b/src/o2simplecrypt.cpp
@@ -102,7 +102,7 @@ QByteArray O0SimpleCrypt::encryptToByteArray(QByteArray plaintext)
         flags |= CryptoFlagCompression;
     } else if (m_compressionMode == CompressionAuto) {
         QByteArray compressed = qCompress(ba, 9);
-        if (compressed.count() < ba.count()) {
+        if (compressed.size() < ba.size()) {
             ba = compressed;
             flags |= CryptoFlagCompression;
         }
@@ -136,7 +136,7 @@ QByteArray O0SimpleCrypt::encryptToByteArray(QByteArray plaintext)
     int pos(0);
     char lastChar(0);
 
-    int cnt = ba.count();
+    int cnt = ba.size();
 
     while (pos < cnt) {
         ba[pos] = ba.at(pos) ^ m_keyParts.at(pos % 8) ^ lastChar;
@@ -220,7 +220,7 @@ QByteArray O0SimpleCrypt::decryptToByteArray(QByteArray cypher)
 
     ba = ba.mid(2);
     int pos(0);
-    int cnt(ba.count());
+    int cnt(ba.size());
     char lastChar = 0;
 
     while (pos < cnt) {


### PR DESCRIPTION
Qt 6.4.x has deprecated QByteArray::count()
```
src/o2simplecrypt.cpp:105:24: warning: 'count' is deprecated: Use size() or length() instead. [-Wdeprecated-declarations]
        if (compressed.count() < ba.count()) {
```